### PR TITLE
Fix required rule for updating unchanged attachment field

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+coverage_clover: build/logs/clover.xml

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+; This file is for unifying the coding style for different editors and IDEs.
+; More information at http://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+indent_size = 4
+indent_style = space
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/.travis.yml        export-ignore
+/phpunit.xml.dist   export-ignore
+/.scrutinizer.yml   export-ignore
+/tests              export-ignore
+/.editorconfig      export-ignore

--- a/.github/workflows/run-composer-normalize.yml
+++ b/.github/workflows/run-composer-normalize.yml
@@ -1,0 +1,28 @@
+name: normalize composer.json
+
+on:
+    push:
+        paths:
+            - composer.json
+
+jobs:
+    normalize:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Git checkout
+              uses: actions/checkout@v2
+
+            -  name: Add HTTP basic auth credentials
+               run: echo '${{ secrets.COMPOSER_AUTH_JSON }}' > $GITHUB_WORKSPACE/auth.json
+
+            - name: Validate Composer configuration
+              run: composer validate --strict
+
+            - name: Normalize composer.json
+              run: |
+                  composer global require ergebnis/composer-normalize
+                  composer normalize
+
+            - uses: stefanzweifel/git-auto-commit-action@v4.0.0
+              with:
+                  commit_message: normalize composer.json

--- a/.github/workflows/run-coverage.yml
+++ b/.github/workflows/run-coverage.yml
@@ -1,0 +1,48 @@
+name: run-tests
+
+on: [push, pull_request]
+
+jobs:
+    coverage:
+        runs-on: ${{ matrix.os }}
+        strategy:
+            fail-fast: true
+            matrix:
+                os: [ubuntu-latest]
+                php: [8.0]
+                dependency-version: [prefer-stable]
+
+        name: P${{ matrix.php }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v2
+
+            -  name: Add HTTP basic auth credentials
+               run: echo '${{ secrets.COMPOSER_AUTH_JSON }}' > $GITHUB_WORKSPACE/auth.json
+
+            - name: Cache dependencies
+              uses: actions/cache@v2
+              with:
+                  path: ~/.composer/cache/files
+                  key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: ${{ matrix.php }}
+                  extensions: dom, curl, libxml, mbstring, zip
+                  coverage: pcov
+
+            - name: Install dependencies
+              run: composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
+
+            - name: Execute tests with coverage
+              run: composer coverage
+
+            - name: Upload coverage results to Coveralls
+              env:
+                  COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  composer global require php-coveralls/php-coveralls
+                  php-coveralls

--- a/.github/workflows/run-fix-code-style.yml
+++ b/.github/workflows/run-fix-code-style.yml
@@ -1,0 +1,41 @@
+name: Fix Code Style
+
+on:
+    push:
+
+jobs:
+    fix-style:
+        name: Fix Code Style
+        runs-on: ${{ matrix.os }}
+        strategy:
+            fail-fast: true
+            matrix:
+                os: [ ubuntu-latest ]
+                php: [ 8.0 ]
+                dependency-version: [ prefer-stable ]
+        env:
+            COMPOSER_NO_INTERACTION: 1
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v2
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: ${{ matrix.php }}
+                  extensions: dom, curl, libxml, mbstring, zip
+                  coverage: pcov
+
+            -  name: Add HTTP basic auth credentials
+               run: echo '${{ secrets.COMPOSER_AUTH_JSON }}' > $GITHUB_WORKSPACE/auth.json
+
+            - name: Install dependencies
+              run: composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
+
+            - run: composer fix-style
+              continue-on-error: true
+
+            - uses: stefanzweifel/git-auto-commit-action@v4
+              with:
+                  commit_message: composer fix-style

--- a/.github/workflows/run-static-analysis.yml
+++ b/.github/workflows/run-static-analysis.yml
@@ -1,0 +1,41 @@
+name: run-static-analysis
+
+on: [push, pull_request]
+
+jobs:
+    static-analysis:
+        runs-on: ${{ matrix.os }}
+        strategy:
+            fail-fast: true
+            matrix:
+                os: [ubuntu-latest]
+                php: [8.0]
+                dependency-version: [prefer-stable]
+
+        name: P${{ matrix.php }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v2
+
+            -  name: Add HTTP basic auth credentials
+               run: echo '${{ secrets.COMPOSER_AUTH_JSON }}' > $GITHUB_WORKSPACE/auth.json
+
+            - name: Cache dependencies
+              uses: actions/cache@v2
+              with:
+                  path: ~/.composer/cache/files
+                  key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: ${{ matrix.php }}
+                  extensions: dom, curl, libxml, mbstring, zip
+                  coverage: pcov
+
+            - name: Install dependencies
+              run: composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
+
+            - name: Execute static code analysis
+              run: composer analyze

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,46 @@
+name: run-tests
+
+on: [push, pull_request]
+
+jobs:
+    test:
+        runs-on: ${{ matrix.os }}
+        strategy:
+            fail-fast: true
+            matrix:
+                os: [ubuntu-latest]
+                php: [7.4, 8.0]
+                dependency-version: [prefer-lowest, prefer-stable]
+
+        name: P${{ matrix.php }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v2
+
+            -  name: Add HTTP basic auth credentials
+               run: echo '${{ secrets.COMPOSER_AUTH_JSON }}' > $GITHUB_WORKSPACE/auth.json
+
+            - name: Cache dependencies
+              uses: actions/cache@v2
+              with:
+                  path: ~/.composer/cache/files
+                  key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: ${{ matrix.php }}
+                  extensions: dom, curl, libxml, mbstring, zip
+                  coverage: none
+
+            - name: Setup Problem Matches
+              run: |
+                  echo "::add-matcher::${{ runner.tool_cache }}/php.json"
+                  echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+            - name: Install dependencies
+              run: composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
+
+            - name: Execute tests
+              run: composer test

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
-/vendor
-/node_modules
+.php_cs.cache
+.php_cs.tests.cache
+.phpunit.cache
 auth.json
-composer.phar
+build
 composer.lock
+composer.phar
+phpstan.neon
 phpunit.xml
+vendor

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /vendor
 /node_modules
+auth.json
 composer.phar
 composer.lock
 phpunit.xml

--- a/.php_cs.common.php
+++ b/.php_cs.common.php
@@ -1,0 +1,64 @@
+<?php
+
+// Share common rules between non-test and test files
+return [
+    '@PSR12' => true,
+    'blank_line_after_opening_tag' => true,
+    'braces' => [
+        'allow_single_line_anonymous_class_with_empty_body' => true,
+    ],
+    'compact_nullable_typehint' => true,
+    'declare_equal_normalize' => true,
+    'lowercase_cast' => true,
+    'lowercase_static_reference' => true,
+    'new_with_braces' => true,
+    'no_blank_lines_after_class_opening' => true,
+    'no_leading_import_slash' => true,
+    'no_whitespace_in_blank_line' => true,
+    'ordered_class_elements' => [
+        'order' => [
+            'use_trait',
+        ],
+    ],
+    'ordered_imports' => [
+        'imports_order' => [
+            'class',
+            'function',
+            'const',
+        ],
+        'sort_algorithm' => 'alpha',
+    ],
+    'return_type_declaration' => true,
+    'short_scalar_cast' => true,
+    'single_blank_line_before_namespace' => true,
+    'single_trait_insert_per_statement' => true,
+    'ternary_operator_spaces' => true,
+    'not_operator_with_successor_space' => true,
+    'visibility_required' => [
+        'elements' => [
+            'const',
+            'method',
+            'property',
+        ],
+    ],
+
+    // Further quality-of-life improvements
+    'array_syntax' => [
+        'syntax' => 'short',
+    ],
+    'concat_space' => [
+        'spacing' => 'one',
+    ],
+    'fully_qualified_strict_types' => true,
+    'native_function_invocation' => [
+        'include' => [],
+        'strict' => true,
+    ],
+    'no_unused_imports' => true,
+    'single_quote' => true,
+    'space_after_semicolon' => true,
+    'trailing_comma_in_multiline_array' => true,
+    'trim_array_spaces' => true,
+    'unary_operator_spaces' => true,
+    'whitespace_after_comma_in_array' => true,
+];

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,0 +1,14 @@
+<?php
+require __DIR__ . '/vendor/autoload.php';
+
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__)
+    ->exclude('tests');
+
+$config = require __DIR__ . '/.php_cs.common.php';
+
+return PhpCsFixer\Config::create()
+    ->setFinder($finder)
+    ->setRules($config)
+    ->setRiskyAllowed(true)
+    ->setCacheFile(__DIR__ . '/.php_cs.cache');

--- a/.php_cs.tests.php
+++ b/.php_cs.tests.php
@@ -1,0 +1,22 @@
+<?php
+require __DIR__ . '/vendor/autoload.php';
+
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__ . '/tests')
+    ->exclude('__snapshots__');
+
+$config = require __DIR__ . '/.php_cs.common.php';
+
+// Additional rules for tests
+$config = array_merge(
+    $config,
+    [
+        'declare_strict_types' => true,
+    ]
+);
+
+return PhpCsFixer\Config::create()
+    ->setFinder($finder)
+    ->setRules($config)
+    ->setRiskyAllowed(true)
+    ->setCacheFile(__DIR__ . '/.php_cs.tests.cache');

--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,13 @@
         "laravel/nova": "^1.0|^2.0|^3.0"
     },
     "require-dev": {
+        "friendsofphp/php-cs-fixer": "^2.18",
+        "nunomaduro/larastan": "^0.7.3",
         "orchestra/testbench": "^6.7",
         "phpstan/phpstan-mockery": "^0.12.13",
         "phpstan/phpstan-phpunit": "^0.12.18",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.5",
+        "thecodingmachine/phpstan-safe-rule": "^1.0"
     },
     "autoload": {
         "psr-4": {
@@ -40,5 +43,18 @@
         "sort-packages": true
     },
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "scripts": {
+        "analyze": "@php vendor/phpstan/phpstan/phpstan analyse --memory-limit 1G",
+        "check-style": [
+            "php-cs-fixer fix --diff --diff-format=udiff --dry-run",
+            "php-cs-fixer fix --diff --diff-format=udiff --dry-run --config=.php_cs.tests.php"
+        ],
+        "coverage": "@php vendor/phpunit/phpunit/phpunit",
+        "fix-style": [
+            "php-cs-fixer fix",
+            "php-cs-fixer fix --config=.php_cs.tests.php"
+        ],
+        "test": "@php vendor/phpunit/phpunit/phpunit --no-coverage"
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -9,10 +9,11 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^7.2.5 || ^8.0",
-        "czim/laravel-paperclip": "^2.7 || ^3.0",
-        "illuminate/database": "^7.0 || ^8.0",
-        "laravel/nova": "^1.0 || ^2.0 || ^3.0"
+        "php": "^7.2.5|^8.0",
+        "cakephp/chronos": "^2.0",
+        "czim/laravel-paperclip": "^3.0",
+        "illuminate/database": "^7.0|^8.0",
+        "laravel/nova": "^3.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.18",

--- a/composer.json
+++ b/composer.json
@@ -9,10 +9,10 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^7.2.5|^8.0",
+        "php": "^7.2.5 || ^8.0",
         "cakephp/chronos": "^2.0",
         "czim/laravel-paperclip": "^3.0",
-        "illuminate/database": "^7.0|^8.0",
+        "illuminate/database": "^7.0 || ^8.0",
         "laravel/nova": "^3.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.18",
+        "illuminate/database": "^8.2",
         "nunomaduro/larastan": "^0.7.3",
         "orchestra/testbench": "^6.7",
         "phpstan/phpstan-mockery": "^0.12.13",

--- a/composer.json
+++ b/composer.json
@@ -8,13 +8,32 @@
         "paperclip"
     ],
     "license": "MIT",
+    "repositories": [
+        {
+            "type": "composer",
+            "url": "https://nova.laravel.com"
+        }
+    ],
     "require": {
-        "php": ">=7.1.0",
-        "czim/laravel-paperclip": "^2.7|^3.0"
+        "php": "^7.2.5|^8.0",
+        "czim/laravel-paperclip": "^2.7|^3.0",
+        "illuminate/database": "^7.0|^8.0",
+        "laravel/nova": "^1.0|^2.0|^3.0"
+    },
+    "require-dev": {
+        "orchestra/testbench": "^6.7",
+        "phpstan/phpstan-mockery": "^0.12.13",
+        "phpstan/phpstan-phpunit": "^0.12.18",
+        "phpunit/phpunit": "^9.5"
     },
     "autoload": {
         "psr-4": {
             "DanielDeWit\\NovaPaperclip\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "DanielDeWit\\NovaPaperclip\\Tests\\": "tests/"
         }
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,11 @@
         "php": "^7.2.5 || ^8.0",
         "cakephp/chronos": "^2.0",
         "czim/laravel-paperclip": "^3.0",
-        "illuminate/database": "^7.0 || ^8.0",
+        "illuminate/database": "^7.0 || ^8.2",
         "laravel/nova": "^3.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.18",
-        "illuminate/database": "^8.2",
         "nunomaduro/larastan": "^0.7.3",
         "orchestra/testbench": "^6.7",
         "phpstan/phpstan-mockery": "^0.12.13",

--- a/composer.json
+++ b/composer.json
@@ -8,17 +8,11 @@
         "paperclip"
     ],
     "license": "MIT",
-    "repositories": [
-        {
-            "type": "composer",
-            "url": "https://nova.laravel.com"
-        }
-    ],
     "require": {
-        "php": "^7.2.5|^8.0",
-        "czim/laravel-paperclip": "^2.7|^3.0",
-        "illuminate/database": "^7.0|^8.0",
-        "laravel/nova": "^1.0|^2.0|^3.0"
+        "php": "^7.2.5 || ^8.0",
+        "czim/laravel-paperclip": "^2.7 || ^3.0",
+        "illuminate/database": "^7.0 || ^8.0",
+        "laravel/nova": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.18",
@@ -28,6 +22,9 @@
         "phpstan/phpstan-phpunit": "^0.12.18",
         "phpunit/phpunit": "^9.5",
         "thecodingmachine/phpstan-safe-rule": "^1.0"
+    },
+    "config": {
+        "sort-packages": true
     },
     "autoload": {
         "psr-4": {
@@ -39,9 +36,12 @@
             "DanielDeWit\\NovaPaperclip\\Tests\\": "tests/"
         }
     },
-    "config": {
-        "sort-packages": true
-    },
+    "repositories": [
+        {
+            "type": "composer",
+            "url": "https://nova.laravel.com"
+        }
+    ],
     "minimum-stability": "dev",
     "prefer-stable": true,
     "scripts": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,11 @@
+includes:
+    - vendor/nunomaduro/larastan/extension.neon
+    - vendor/phpstan/phpstan-mockery/extension.neon
+    - vendor/phpstan/phpstan-phpunit/extension.neon
+    - vendor/phpstan/phpstan-phpunit/rules.neon
+
+parameters:
+  level: max
+  paths:
+    - src
+    - tests

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,6 +3,7 @@ includes:
     - vendor/phpstan/phpstan-mockery/extension.neon
     - vendor/phpstan/phpstan-phpunit/extension.neon
     - vendor/phpstan/phpstan-phpunit/rules.neon
+    - vendor/thecodingmachine/phpstan-safe-rule/phpstan-safe-rule.neon
 
 parameters:
   level: max

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,6 +16,9 @@
         <include>
             <directory suffix=".php">./src</directory>
         </include>
+        <report>
+            <clover outputFile="./build/logs/clover.xml"/>
+        </report>
     </coverage>
     <php>
         <env name="DB_CONNECTION" value="testing"/>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="./vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Integration">
+            <directory>./tests/Integration</directory>
+        </testsuite>
+        <testsuite name="Unit">
+            <directory>./tests/Unit</directory>
+        </testsuite>
+    </testsuites>
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </coverage>
+    <php>
+        <env name="DB_CONNECTION" value="testing"/>
+        <env name="APP_KEY" value="base64:2fl+Ktvkfl+Fuz4Qp/A75G2RTiWVA/ZoKZvp6fiiM10="/>
+        <env name="APP_DEBUG" value="true"/>
+    </php>
+</phpunit>

--- a/src/PaperclipFile.php
+++ b/src/PaperclipFile.php
@@ -64,6 +64,36 @@ class PaperclipFile extends File
         };
     }
 
+    /**
+     * @param NovaRequest $request
+     * @return mixed[]
+     */
+    public function getUpdateRules(NovaRequest $request): array
+    {
+        $rules = parent::getUpdateRules($request);
+
+        if (! array_key_exists($this->attribute, $rules)) {
+            return $rules;
+        }
+
+        if (! in_array('required', $rules[$this->attribute])) {
+            return $rules;
+        }
+
+        $model = $request->findModelOrFail($request->route('resourceId'));
+
+        /** @var AttachmentInterface $attachment */
+        $attachment = $model->getAttribute($this->attribute);
+
+        if ($attachment->exists()) {
+            $requiredIndex = array_search('required', $rules[$this->attribute]);
+
+            unset($rules[$this->attribute][$requiredIndex]);
+        }
+
+        return $rules;
+    }
+
     public function mimes(array $mimes)
     {
         $this->withMeta([

--- a/src/PaperclipFile.php
+++ b/src/PaperclipFile.php
@@ -32,20 +32,17 @@ class PaperclipFile extends File
                 /** @var Attachment $attachment */
                 $attachment = $model->{$this->attribute};
 
-                /** @var Storage $storage */
                 $storage = $model->{$this->attribute}->getStorage();
 
                 return Storage::disk($storage)->download($attachment->path(), $attachment->originalFilename());
             })
             ->delete(function (NovaRequest $request, Model $model) {
-                if ( ! $this->value) {
+                if (! $this->value) {
                     return;
                 }
 
                 $model->{$this->attribute} = Attachment::NULL_ATTACHMENT;
                 $model->save();
-
-                return;
             });
     }
 
@@ -94,7 +91,11 @@ class PaperclipFile extends File
         return $rules;
     }
 
-    public function mimes(array $mimes)
+    /**
+     * @param string[] $mimes
+     * @return $this
+     */
+    public function mimes(array $mimes): self
     {
         $this->withMeta([
             'mimes' => $mimes,
@@ -103,7 +104,7 @@ class PaperclipFile extends File
         return $this;
     }
 
-    public function min(int $min)
+    public function min(int $min): self
     {
         $this->withMeta([
             'min' => $min,
@@ -112,7 +113,7 @@ class PaperclipFile extends File
         return $this;
     }
 
-    public function max(int $max)
+    public function max(int $max): self
     {
         $this->withMeta([
             'max' => $max,
@@ -121,7 +122,7 @@ class PaperclipFile extends File
         return $this;
     }
 
-    public function size(int $size)
+    public function size(int $size): self
     {
         $this->withMeta([
             'size' => $size,

--- a/src/PaperclipImage.php
+++ b/src/PaperclipImage.php
@@ -33,7 +33,7 @@ class PaperclipImage extends PaperclipFile
             });
     }
 
-    public function width(int $width)
+    public function width(int $width): self
     {
         $this->withMeta([
             'width' => $width,
@@ -42,7 +42,7 @@ class PaperclipImage extends PaperclipFile
         return $this;
     }
 
-    public function minWidth(int $width)
+    public function minWidth(int $width): self
     {
         $this->withMeta([
             'minWidth' => $width,
@@ -51,7 +51,7 @@ class PaperclipImage extends PaperclipFile
         return $this;
     }
 
-    public function maxWidth(int $width)
+    public function maxWidth(int $width): self
     {
         $this->withMeta([
             'maxWidth' => $width,
@@ -60,7 +60,7 @@ class PaperclipImage extends PaperclipFile
         return $this;
     }
 
-    public function height(int $height)
+    public function height(int $height): self
     {
         $this->withMeta([
             'height' => $height,
@@ -69,7 +69,7 @@ class PaperclipImage extends PaperclipFile
         return $this;
     }
 
-    public function minHeight(int $height)
+    public function minHeight(int $height): self
     {
         $this->withMeta([
             'minHeight' => $height,
@@ -78,7 +78,7 @@ class PaperclipImage extends PaperclipFile
         return $this;
     }
 
-    public function maxHeight(int $height)
+    public function maxHeight(int $height): self
     {
         $this->withMeta([
             'maxHeight' => $height,

--- a/tests/Integration/AbstractIntegrationTest.php
+++ b/tests/Integration/AbstractIntegrationTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DanielDeWit\NovaPaperclip\Tests\Integration;
+
+use Czim\Paperclip\Providers\PaperclipServiceProvider;
+use DanielDeWit\NovaPaperclip\Tests\stubs\App\Models\User;
+use DanielDeWit\NovaPaperclip\Tests\stubs\App\Providers\NovaServiceProvider;
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Nova\NovaCoreServiceProvider;
+use Orchestra\Testbench\TestCase;
+
+class AbstractIntegrationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->be(User::factory()->create());
+    }
+
+    /**
+     * @param Application $app
+     * @return string[]
+     */
+    protected function getPackageProviders($app): array
+    {
+        return [
+            NovaCoreServiceProvider::class,
+            NovaServiceProvider::class,
+            PaperclipServiceProvider::class,
+        ];
+    }
+
+    protected function defineDatabaseMigrations(): void
+    {
+        $this->loadLaravelMigrations();
+        $this->loadMigrationsFrom($this->getStubsPath('database' . DIRECTORY_SEPARATOR . 'migrations'));
+    }
+
+    /**
+     * @param Application $app
+     */
+    protected function defineEnvironment($app): void
+    {
+        $app['config']->set('paperclip.storage.disk', 'public');
+    }
+
+    protected function getStubsPath(string $path): string
+    {
+        return dirname(__DIR__) . DIRECTORY_SEPARATOR . 'stubs' . DIRECTORY_SEPARATOR . $path;
+    }
+}

--- a/tests/Integration/AbstractIntegrationTest.php
+++ b/tests/Integration/AbstractIntegrationTest.php
@@ -12,7 +12,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Nova\NovaCoreServiceProvider;
 use Orchestra\Testbench\TestCase;
 
-class AbstractIntegrationTest extends TestCase
+abstract class AbstractIntegrationTest extends TestCase
 {
     use RefreshDatabase;
 

--- a/tests/Integration/PaperclipFileTest.php
+++ b/tests/Integration/PaperclipFileTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DanielDeWit\NovaPaperclip\Tests\Integration;
+
+use DanielDeWit\NovaPaperclip\Tests\stubs\App\Models\ModelWithFile;
+use DanielDeWit\NovaPaperclip\Tests\stubs\App\Nova\Resources\ModelWithFileResource;
+use Illuminate\Http\UploadedFile;
+
+class PaperclipFileTest extends AbstractIntegrationTest
+{
+    /**
+     * @test
+     */
+    public function it_updates_a_resource_without_a_file_for_a_model_that_has_a_file(): void
+    {
+        $model = ModelWithFile::factory()->create([
+            'file' => UploadedFile::fake()->create('document.pdf', 1024),
+        ]);
+
+        $this->putJson('nova-api/' . ModelWithFileResource::uriKey() . '/' . $model->getKey())
+            ->assertJsonMissingValidationErrors('file');
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_an_error_when_updating_a_resource_without_a_file_for_a_model_that_does_not_have_a_file(): void
+    {
+        $model = ModelWithFile::factory()->create([
+            'file' => null,
+        ]);
+
+        $this->putJson('nova-api/' . ModelWithFileResource::uriKey() . '/' . $model->getKey())
+            ->assertJsonValidationErrors('file');
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_an_error_when_updating_a_resource_without_a_file_for_a_model_that_had_a_file(): void
+    {
+        $model = ModelWithFile::factory()->create([
+            'file' => UploadedFile::fake()->create('document.pdf', 1024),
+        ]);
+
+        $this->deleteJson('nova-api/' . ModelWithFileResource::uriKey() . '/' . $model->getKey() . '/field/file')
+            ->assertStatus(200);
+
+        $this->putJson('nova-api/' . ModelWithFileResource::uriKey() . '/' . $model->getKey())
+            ->assertJsonValidationErrors('file');
+    }
+}

--- a/tests/Integration/PaperclipImageTest.php
+++ b/tests/Integration/PaperclipImageTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DanielDeWit\NovaPaperclip\Tests\Integration;
+
+use DanielDeWit\NovaPaperclip\Tests\stubs\App\Models\ModelWithImage;
+use DanielDeWit\NovaPaperclip\Tests\stubs\App\Nova\Resources\ModelWithImageResource;
+use Illuminate\Http\UploadedFile;
+
+class PaperclipImageTest extends AbstractIntegrationTest
+{
+    /**
+     * @test
+     */
+    public function it_updates_a_resource_without_an_image_for_a_model_that_has_an_image(): void
+    {
+        $model = ModelWithImage::factory()->create([
+            'image' => UploadedFile::fake()->image('image.jpg'),
+        ]);
+
+        $this->putJson('nova-api/' . ModelWithImageResource::uriKey() . '/' . $model->getKey())
+            ->assertJsonMissingValidationErrors('image');
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_an_error_when_updating_a_resource_without_an_image_for_a_model_that_does_not_have_an_image(): void
+    {
+        $model = ModelWithImage::factory()->create([
+            'image' => null,
+        ]);
+
+        $this->putJson('nova-api/' . ModelWithImageResource::uriKey() . '/' . $model->getKey())
+            ->assertJsonValidationErrors('image');
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_an_error_when_updating_a_resource_without_an_image_for_a_model_that_had_an_image(): void
+    {
+        $model = ModelWithImage::factory()->create([
+            'image' => UploadedFile::fake()->image('image.jpg'),
+        ]);
+
+        $this->deleteJson('nova-api/' . ModelWithImageResource::uriKey() . '/' . $model->getKey() . '/field/image')
+            ->assertStatus(200);
+
+        $this->putJson('nova-api/' . ModelWithImageResource::uriKey() . '/' . $model->getKey())
+            ->assertJsonValidationErrors('image');
+    }
+}

--- a/tests/Unit/AbstractUnitTest.php
+++ b/tests/Unit/AbstractUnitTest.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DanielDeWit\NovaPaperclip\Tests\Unit;
+
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+
+abstract class AbstractUnitTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+}

--- a/tests/stubs/App/Models/ModelWithFile.php
+++ b/tests/stubs/App/Models/ModelWithFile.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DanielDeWit\NovaPaperclip\Tests\stubs\App\Models;
+
+use Czim\Paperclip\Contracts\AttachableInterface;
+use Czim\Paperclip\Model\PaperclipTrait;
+use DanielDeWit\NovaPaperclip\Tests\stubs\database\factories\ModelWithFileFactory;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ModelWithFile extends Model implements AttachableInterface
+{
+    use HasFactory;
+    use PaperclipTrait;
+
+    protected $table = 'models_with_file';
+
+    /**
+     * @var string[]
+     */
+    protected $fillable = [
+        'file',
+    ];
+
+    /**
+     * @param array<string, mixed> $attributes
+     */
+    public function __construct(array $attributes = [])
+    {
+        $this->hasAttachedFile('file');
+
+        parent::__construct($attributes);
+    }
+
+    protected static function newFactory(): Factory
+    {
+        return new ModelWithFileFactory();
+    }
+}

--- a/tests/stubs/App/Models/ModelWithImage.php
+++ b/tests/stubs/App/Models/ModelWithImage.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DanielDeWit\NovaPaperclip\Tests\stubs\App\Models;
+
+use Czim\Paperclip\Contracts\AttachableInterface;
+use Czim\Paperclip\Model\PaperclipTrait;
+use DanielDeWit\NovaPaperclip\Tests\stubs\database\factories\ModelWithImageFactory;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ModelWithImage extends Model implements AttachableInterface
+{
+    use HasFactory;
+    use PaperclipTrait;
+
+    protected $table = 'models_with_image';
+
+    /**
+     * @var string[]
+     */
+    protected $fillable = [
+        'image',
+    ];
+
+    /**
+     * @param array<string, mixed> $attributes
+     */
+    public function __construct(array $attributes = [])
+    {
+        $this->hasAttachedFile('image');
+
+        parent::__construct($attributes);
+    }
+
+    protected static function newFactory(): Factory
+    {
+        return new ModelWithImageFactory();
+    }
+}

--- a/tests/stubs/App/Models/User.php
+++ b/tests/stubs/App/Models/User.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DanielDeWit\NovaPaperclip\Tests\stubs\App\Models;
+
+use DanielDeWit\NovaPaperclip\Tests\stubs\database\factories\UserFactory;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Foundation\Auth\User as BaseUser;
+
+class User extends BaseUser
+{
+    use HasFactory;
+
+    protected static function newFactory(): Factory
+    {
+        return new UserFactory();
+    }
+}

--- a/tests/stubs/App/Nova/Resources/ModelWithFileResource.php
+++ b/tests/stubs/App/Nova/Resources/ModelWithFileResource.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DanielDeWit\NovaPaperclip\Tests\stubs\App\Nova\Resources;
+
+use DanielDeWit\NovaPaperclip\PaperclipFile;
+use DanielDeWit\NovaPaperclip\Tests\stubs\App\Models\ModelWithFile;
+use Illuminate\Http\Request;
+use Laravel\Nova\Fields\Field;
+use Laravel\Nova\Fields\ID;
+use Laravel\Nova\Resource;
+
+class ModelWithFileResource extends Resource
+{
+    /**
+     * @var string
+     */
+    public static $model = ModelWithFile::class;
+
+    /**
+     * @param Request $request
+     * @return Field[]
+     */
+    public function fields(Request $request): array
+    {
+        return [
+            ID::make(),
+
+            PaperclipFile::make('File', 'file')
+                ->rules('required', 'file'),
+        ];
+    }
+}

--- a/tests/stubs/App/Nova/Resources/ModelWithImageResource.php
+++ b/tests/stubs/App/Nova/Resources/ModelWithImageResource.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DanielDeWit\NovaPaperclip\Tests\stubs\App\Nova\Resources;
+
+use DanielDeWit\NovaPaperclip\PaperclipImage;
+use DanielDeWit\NovaPaperclip\Tests\stubs\App\Models\ModelWithImage;
+use Illuminate\Http\Request;
+use Laravel\Nova\Fields\Field;
+use Laravel\Nova\Fields\ID;
+use Laravel\Nova\Resource;
+
+class ModelWithImageResource extends Resource
+{
+    /**
+     * @var string
+     */
+    public static $model = ModelWithImage::class;
+
+    /**
+     * @param Request $request
+     * @return Field[]
+     */
+    public function fields(Request $request): array
+    {
+        return [
+            ID::make(),
+
+            PaperclipImage::make('Image', 'image')
+                ->rules('required', 'image'),
+        ];
+    }
+}

--- a/tests/stubs/App/Providers/NovaServiceProvider.php
+++ b/tests/stubs/App/Providers/NovaServiceProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DanielDeWit\NovaPaperclip\Tests\stubs\App\Providers;
+
+use DanielDeWit\NovaPaperclip\Tests\stubs\App\Nova\Resources\ModelWithFileResource;
+use DanielDeWit\NovaPaperclip\Tests\stubs\App\Nova\Resources\ModelWithImageResource;
+use Illuminate\Support\Facades\Gate;
+use Laravel\Nova\Nova;
+use Laravel\Nova\NovaApplicationServiceProvider;
+
+class NovaServiceProvider extends NovaApplicationServiceProvider
+{
+    protected function routes(): void
+    {
+        Nova::routes()
+            ->withAuthenticationRoutes()
+            ->register();
+    }
+
+    protected function resources(): void
+    {
+        Nova::resources([
+            ModelWithFileResource::class,
+            ModelWithImageResource::class,
+        ]);
+    }
+
+    protected function gate(): void
+    {
+        Gate::define('viewNova', function () {
+            return true;
+        });
+    }
+}

--- a/tests/stubs/database/factories/ModelWithFileFactory.php
+++ b/tests/stubs/database/factories/ModelWithFileFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DanielDeWit\NovaPaperclip\Tests\stubs\database\factories;
+
+use DanielDeWit\NovaPaperclip\Tests\stubs\App\Models\ModelWithFile;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ModelWithFileFactory extends Factory
+{
+    protected $model = ModelWithFile::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'file' => null,
+        ];
+    }
+}

--- a/tests/stubs/database/factories/ModelWithImageFactory.php
+++ b/tests/stubs/database/factories/ModelWithImageFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DanielDeWit\NovaPaperclip\Tests\stubs\database\factories;
+
+use DanielDeWit\NovaPaperclip\Tests\stubs\App\Models\ModelWithImage;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ModelWithImageFactory extends Factory
+{
+    protected $model = ModelWithImage::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'image' => null,
+        ];
+    }
+}

--- a/tests/stubs/database/factories/UserFactory.php
+++ b/tests/stubs/database/factories/UserFactory.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DanielDeWit\NovaPaperclip\Tests\stubs\database\factories;
+
+use DanielDeWit\NovaPaperclip\Tests\stubs\App\Models\User;
+use Orchestra\Testbench\Factories\UserFactory as BaseUserFactory;
+
+class UserFactory extends BaseUserFactory
+{
+    protected $model = User::class;
+}

--- a/tests/stubs/database/migrations/0000_00_00_000000_create_models_with_file_table.php
+++ b/tests/stubs/database/migrations/0000_00_00_000000_create_models_with_file_table.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateModelsWithFileTable extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('models_with_file', function (Blueprint $table) {
+            $table->id();
+
+            $table->string('file_file_name')->nullable();
+            $table->integer('file_file_size')->nullable();
+            $table->string('file_content_type')->nullable();
+            $table->string('file_variants', 255)->nullable();
+            $table->timestamp('file_updated_at')->nullable();
+
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('models_with_file');
+    }
+}

--- a/tests/stubs/database/migrations/0000_00_00_000001_create_models_with_image_table.php
+++ b/tests/stubs/database/migrations/0000_00_00_000001_create_models_with_image_table.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateModelsWithImageTable extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('models_with_image', function (Blueprint $table) {
+            $table->id();
+
+            $table->string('image_file_name')->nullable();
+            $table->integer('image_file_size')->nullable();
+            $table->string('image_content_type')->nullable();
+            $table->string('image_variants', 255)->nullable();
+            $table->timestamp('image_updated_at')->nullable();
+
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('models_with_image');
+    }
+}


### PR DESCRIPTION
Making a paperclip field required resulted in an issue that when updating the resource without changing the paperclip field value, it return a validation error. This PR fixes that by checking if the underlying model has an attachment and if so removing the required rule from the update rules.